### PR TITLE
Need stdexcept in iterator.h

### DIFF
--- a/src/librexgen/iterator/iterator.h
+++ b/src/librexgen/iterator/iterator.h
@@ -26,6 +26,7 @@
 #include <librexgen/osdepend.h>
 #include <librexgen/state/serializablestate.h>
 #include <librexgen/state/invaliditeratoridexception.h>
+#include <stdexcept>
 #include <memory>
 
 #ifdef __cplusplus


### PR DESCRIPTION
It seems to complain and will not compile on OpenSUSE Tumbleweed without including <stdexcept>

```
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:93:81: error: no member named 'runtime_error' in namespace 'std'
    bool next()                                           override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:94:81: error: no member named 'runtime_error' in namespace 'std'
    void updateReferences(IteratorState& /* iterState */) override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:95:81: error: no member named 'runtime_error' in namespace 'std'
    void updateAttributes(IteratorState& /* iterState */) override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
In file included from /HDD2/working/rexgen/src/librexgen/regex/groupreference.cpp:20:
In file included from /HDD2/working/rexgen/src/librexgen/iterator/iteratorstate.h:23:
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:93:81: error: no member named 'runtime_error' in namespace 'std'
    bool next()                                           override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:94:81: error: no member named 'runtime_error' in namespace 'std'
    void updateReferences(IteratorState& /* iterState */) override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
/HDD2/working/rexgen/src/librexgen/iterator/iterator.h:95:81: error: no member named 'runtime_error' in namespace 'std'
    void updateAttributes(IteratorState& /* iterState */) override { throw std::runtime_error("not implemented");}
                                                                           ~~~~~^
```